### PR TITLE
Update tutorial for manual approval step

### DIFF
--- a/vpc-ecscluster-lb-fargate-tutorial/chapter1/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter1/README.md
@@ -125,6 +125,8 @@ Leave everything else at the defaults, click `Next` and at the summary page clic
 
 Be patient. Proton will first create the test and production infrastructure (Proton service instances), it will then create the pipeline, and eventually it will trigger the pipeline (which will take roughly 8-10 minutes to go through all the stages). The pipeline is configured to check for future changes on the application repository (the nginx custom application in the context of this tutorial). 
 
+For safety, the pipeline created for your service will not deploy the images automatically. When code build has finished building you should navigate to the two pipelines we created and approve the "Preproduction_Approval" step.
+
 > Important note on IAM roles: note that the developer does not need to specify an IAM role to assume for deploying the resources as part of the wizard. Proton will use the IAM roles the administrator has specified when deploying the environments these service instances bind to.   
 
 This is how the `Overview` tab of your service should look like: 

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter1/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter1/README.md
@@ -125,8 +125,6 @@ Leave everything else at the defaults, click `Next` and at the summary page clic
 
 Be patient. Proton will first create the test and production infrastructure (Proton service instances), it will then create the pipeline, and eventually it will trigger the pipeline (which will take roughly 8-10 minutes to go through all the stages). The pipeline is configured to check for future changes on the application repository (the nginx custom application in the context of this tutorial). 
 
-For safety, the pipeline created for your service will not deploy the images automatically. When code build has finished building you should navigate to the two pipelines we created and approve the "Preproduction_Approval" step.
-
 > Important note on IAM roles: note that the developer does not need to specify an IAM role to assume for deploying the resources as part of the wizard. Proton will use the IAM roles the administrator has specified when deploying the environments these service instances bind to.   
 
 This is how the `Overview` tab of your service should look like: 

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter1/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter1/README.md
@@ -68,7 +68,11 @@ This is where the Jinja magic starts to happen. You are asked to customize the p
 
 The `deployment status` will be `in progress` for a little while and then will report `Succeeded`. 
 
-Go through the `Create environment` workflow once more and configure a new environment called `VPC-ECSCluster-Env-Production`. This time you can pick the previously created IAM service role. 
+Go through the `Create environment` workflow once more and configure a new environment called `VPC-ECSCluster-Env-Production`. 
+
+> Note: For this tutorial it is important that your environment contains the string `Production` (case sensitive). We will be using that in Chapter 2.
+
+This time you can pick the previously created IAM service role. 
 
 At the end of these two workflows you should see your environments ready: 
 

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
@@ -67,7 +67,7 @@ You  Congratulations, you have just updated your first Proton environment by add
 
 Now that we have updated both the environment template and the environments themselves, let's explore updating the services. Here is a situation that you, as a platform admin, may come across: 
 
-Business is requesting that all production deployments are gated by a manual approval from the business (this requires a change in the service pipeline). We still want to automatically deploy changes in our test stage though, so we need to use Proton's template rendering engine to create different behaviors based on the environment.
+Business is requesting that all production deployments are gated by a manual approval to prevent changed from accidentally flowing to production (this requires a change in the service pipeline). We still want to automatically deploy changes in our test stage though, so we need to use Proton's template rendering engine to create different behaviors based on the environment.
 
 First locate the `pipeline_infrastructure` CloudFormation template, navigate to the section where the pipeline `Actions` are declared for each service instance, and add the following `Preproduction_Approval` action (there's a `TODO` comment to help you location the right place to make this change). The result should look like the snippet below:
 

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
@@ -133,7 +133,6 @@ Last but not least add the `EnableExecuteCommand: true` in the `Service` resourc
       {% endif %} 
       ServiceName: '{{service.name}}_{{service_instance.name}}'
 ```
-> As you may have noticed here we are taking a different approach to allow for `exec`ing into containers. While for the pipeline developers could own their destiny related to where they want the manual approval stage, for this feature the platform team needs to have stricter control (e.g. they need to make sure that `exec` is only enabled as a function of the environment name - which they control - and not simply of the service instance name - which devs control- ). So the Jinja check this time is done at the `environment.name` level. 
 
 Now that you modified the service instance and pipeline properties, you can push the changes to GitHub. Proton should detect a new minor version that you can publish. That will become the new `recommended` version: 
 

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
@@ -72,7 +72,7 @@ Business is requesting that all production deployments are gated by a manual app
 First locate the `pipeline_infrastructure` CloudFormation template, navigate to the section where the pipeline `Actions` are declared for each service instance, and add the following `Preproduction_Approval` action (there's a `TODO` comment to help you location the right place to make this change). The result should look like the snippet below:
 
 ```
-{% if 'production' in environment.name %}
+{% if 'Production' in environment.name %}
         - Actions:
             - ActionTypeId:
                 Category: Approval

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
@@ -67,12 +67,12 @@ You  Congratulations, you have just updated your first Proton environment by add
 
 Now that we have updated both the environment template and the environments themselves, let's explore updating the services. Here is a situation that you, as a platform admin, may come across: 
 
-Developers are annoyed that they have to manually approve changes for our test environment. We can use the magic of Proton's Jinja engine to provide this option to our service team.
+Business is requesting that all production deployments are gated by a manual approval from the business (this requires a change in the service pipeline). We still want to automatically deploy changes in our test stage though, so we need to use Proton's template rendering engine to create different behaviors based on the environment.
 
-First locate the `pipeline_infrastructure` CloudFormation template, navigate to the section where the pipeline `Actions` are declared for each service instance, and add an if statement around the `Preproduction_Approval` action. The result should look like the snippet below:
+First locate the `pipeline_infrastructure` CloudFormation template, navigate to the section where the pipeline `Actions` are declared for each service instance, and add the following `Preproduction_Approval` action (there's a `TODO` comment to help you location the right place to make this change). The result should look like the snippet below:
 
 ```
-{% if 'production' in service_instance.name %}
+{% if 'production' in environment.name %}
         - Actions:
             - ActionTypeId:
                 Category: Approval
@@ -85,9 +85,9 @@ First locate the `pipeline_infrastructure` CloudFormation template, navigate to 
           Name: Preproduction_Approval
 {% endif %}
 ``` 
-There is quite a bit of Jinja magic going on here. Here is what's happening. You just placed an action inside a `for` loop (`{%- for service_instance in service_instances %}`) that basically create a `Deploy` action per each service instance you created. What you added above is a piece of code that, basically, says "if the instance_name is called `production` then add a pipeline action that is a manual approval. The developer knows that when they create an instance called `production` Proton will add a manual approval gate. 
+There is quite a bit of Jinja magic going on here. Here is what's happening. You just placed an action inside a `for` loop (`{%- for service_instance in service_instances %}`) that basically create a `Deploy` action per each service instance you created. What you added above is a piece of code that, basically, says "if the environment is called `production` then add a pipeline action that is a manual approval. The developer knows that when they create an instance in an environment called `production` Proton will add a manual approval gate. 
 
-> Note that, in this situation, there is a bit of naming convention here that needs to be agreed between the developer and the platform team. The developers know that when they create an instance called `production` Proton will add a manual approval gate to the pipeline before deploying it. Depending on what you want to achieve, it may be possible to leverage variables that refers to `environments` names rather than `service instance` names to make it fully transparent for the user and allowing the platform team to enforce behaviour further.  
+By referencing the environment name, the platform team is able to enforce best practices for service teams.
 
 You are also getting complaints from developers that they find it hard to debug their applications when they are running in the test environments (your policies do not allow you to enable exec'ing into containers in production but you can enable that for anything that is not production environments). 
 

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
@@ -81,7 +81,7 @@ First locate the `pipeline_infrastructure` CloudFormation template, navigate to 
                 Version: '1'
               InputArtifacts: []
               Name: Approval
-              RunOrder: 0
+              RunOrder: 1
           Name: Preproduction_Approval
 {% endif %}
 ``` 

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
@@ -65,9 +65,9 @@ You  Congratulations, you have just updated your first Proton environment by add
 
 ### Updating the service template [ PLATFORM ADMIN ]
 
-Now that we have updated both the environment template and the environments themselves, let's explore updating the services. Here is a situation that you, as a platform admin, may come across: you are getting requests from developers that they find it hard to debug their applications when they are running in the test environments (your policies do not allow you to enable exec'ing into containers in production but you can enable that for anything that is not production environments). 
+Now that we have updated both the environment template and the environments themselves, let's explore updating the services. Here is a situation that you, as a platform admin, may come across: 
 
-Also, developers are annoyed that they have to manually approve changes for our test environment. Let's use the magic of Proton's Jinja engine to provide this option to our service team.
+Developers are annoyed that they have to manually approve changes for our test environment. We can use the magic of Proton's Jinja engine to provide this option to our service team.
 
 First locate the `pipeline_infrastructure` CloudFormation template, navigate to the section where the pipeline `Actions` are declared for each service instance, and add an if statement around the `Preproduction_Approval` action. The result should look like the snippet below:
 
@@ -89,7 +89,9 @@ There is quite a bit of Jinja magic going on here. Here is what's happening. You
 
 > Note that, in this situation, there is a bit of naming convention here that needs to be agreed between the developer and the platform team. The developers know that when they create an instance called `production` Proton will add a manual approval gate to the pipeline before deploying it. Depending on what you want to achieve, it may be possible to leverage variables that refers to `environments` names rather than `service instance` names to make it fully transparent for the user and allowing the platform team to enforce behaviour further.  
 
-Now let's enable [ECS exec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html) for the service itself (the following changes are required to enable the ECS Exec feature). 
+You are also getting complaints from developers that they find it hard to debug their applications when they are running in the test environments (your policies do not allow you to enable exec'ing into containers in production but you can enable that for anything that is not production environments). 
+
+We can again use Proton's template rendering engine to enable [ECS exec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html) for the test environment while leaving it disabled for production. 
 
 Locate the `instance_infrastructure` CloudFormation template and add the following snippet somewhere in the `Resources` section: 
 

--- a/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
+++ b/vpc-ecscluster-lb-fargate-tutorial/chapter2/README.md
@@ -65,9 +65,11 @@ You  Congratulations, you have just updated your first Proton environment by add
 
 ### Updating the service template [ PLATFORM ADMIN ]
 
-Now that we have updated both the environment template and the environments themselves, let's explore updating the services. Here is a situation that you, as a platform admin, may come across: you are getting requests from developers that they find it hard to debug their applications when they are running in the test environments (your policies do not allow you to enable exec'ing into containers in production but you can enable that for anything that is not production environments). Also, because of some incidents that have occurred over the last few weeks, the business is requesting that all production deployments are gated by a manual approval from the business (this requires a change in the service pipeline). 
+Now that we have updated both the environment template and the environments themselves, let's explore updating the services. Here is a situation that you, as a platform admin, may come across: you are getting requests from developers that they find it hard to debug their applications when they are running in the test environments (your policies do not allow you to enable exec'ing into containers in production but you can enable that for anything that is not production environments). 
 
-First locate the `pipeline_infrastructure` CloudFormation template, navigate to the section where the pipeline `Actions` are declared for each service instance (this is done via Jinja within the `{%- for service_instance in service_instances %}` block). It doesn't matter if it goes before or after the action with `Name: Deploy`, our run order parameter specifies that the approval step should happen first.
+Also, developers are annoyed that they have to manually approve changes for our test environment. Let's use the magic of Proton's Jinja engine to provide this option to our service team.
+
+First locate the `pipeline_infrastructure` CloudFormation template, navigate to the section where the pipeline `Actions` are declared for each service instance, and add an if statement around the `Preproduction_Approval` action. The result should look like the snippet below:
 
 ```
 {% if 'production' in service_instance.name %}

--- a/vpc-ecscluster-lb-fargate-tutorial/lb-fargate-svc/v1/instance_infrastructure/cloudformation.yaml
+++ b/vpc-ecscluster-lb-fargate-tutorial/lb-fargate-svc/v1/instance_infrastructure/cloudformation.yaml
@@ -133,7 +133,7 @@ Resources:
             - '{{environment.outputs.ClusterName}}'
             - '{{service.name}}_{{service_instance.name}}'
       MinCapacity: 1
-      MaxCapacity: 5
+      MaxCapacity: 10
       RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
 
   # Create scaling policies for the service

--- a/vpc-ecscluster-lb-fargate-tutorial/lb-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
+++ b/vpc-ecscluster-lb-fargate-tutorial/lb-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
@@ -596,7 +596,6 @@ Resources:
               RunOrder: 1
           Name: Build 
 {%- for service_instance in service_instances %}
-{% if 'Prod' in service_instance.name %}
         - Actions:
             - ActionTypeId:
                 Category: Approval
@@ -607,7 +606,6 @@ Resources:
               Name: Approval
               RunOrder: 0
           Name: Preproduction_Approval
-{% endif %}
         - Actions:
             - ActionTypeId:
                 Category: Build

--- a/vpc-ecscluster-lb-fargate-tutorial/lb-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
+++ b/vpc-ecscluster-lb-fargate-tutorial/lb-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
@@ -612,7 +612,7 @@ Resources:
                 Fn::GetAtt:
                   - PipelineDeployCodePipelineActionRole
                   - Arn
-              RunOrder: 1
+              RunOrder: 2
           Name: 'Deploy-{{service_instance.name}}'
 {%- endfor %}
       ArtifactStore:

--- a/vpc-ecscluster-lb-fargate-tutorial/lb-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
+++ b/vpc-ecscluster-lb-fargate-tutorial/lb-fargate-svc/v1/pipeline_infrastructure/cloudformation.yaml
@@ -596,17 +596,7 @@ Resources:
               RunOrder: 1
           Name: Build 
 {%- for service_instance in service_instances %}
-        - Actions:
-            - ActionTypeId:
-                Category: Approval
-                Owner: AWS
-                Provider: Manual
-                Version: '1'
-              InputArtifacts: []
-              Name: Approval
-              RunOrder: 0
-          Name: Preproduction_Approval
-        - Actions:
+        - Actions: # TODO: Add a manual approval step for all Prod environments before this action
             - ActionTypeId:
                 Category: Build
                 Owner: AWS

--- a/vpc-ecscluster-lb-fargate-tutorial/vpc-ecscluster-env/v1/infrastructure/cloudformation.yaml
+++ b/vpc-ecscluster-lb-fargate-tutorial/vpc-ecscluster-env/v1/infrastructure/cloudformation.yaml
@@ -72,7 +72,7 @@ Resources:
     Properties:
       SubnetId: !Ref PublicSubnetTwo
       RouteTableId: !Ref PublicRouteTable
-      
+
   # ECS Resources
   ECSCluster:
     Type: AWS::ECS::Cluster

--- a/vpc-ecscluster-lb-fargate-tutorial/vpc-ecscluster-env/v1/infrastructure/cloudformation.yaml
+++ b/vpc-ecscluster-lb-fargate-tutorial/vpc-ecscluster-env/v1/infrastructure/cloudformation.yaml
@@ -72,38 +72,6 @@ Resources:
     Properties:
       SubnetId: !Ref PublicSubnetTwo
       RouteTableId: !Ref PublicRouteTable
-  VPCFlowLog:
-    Type: AWS::EC2::FlowLog
-    Properties:
-      DeliverLogsPermissionArn: !GetAtt FlowLogRole.Arn
-      LogGroupName: !Ref FlowLogsGroup
-      ResourceId: !Ref VPC
-      ResourceType: VPC
-      TrafficType: ALL
-  FlowLogRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: [vpc-flow-logs.amazonaws.com]
-          Action: ['sts:AssumeRole']
-      Path: /
-      ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/CloudWatchLogsFullAccess'
-  FlowLogsGroup: 
-    Type: AWS::Logs::LogGroup
-    Properties: 
-      RetentionInDays: 7
-
-  # ECS Resources
-  ECSCluster:
-    Type: AWS::ECS::Cluster
-    Properties:
-      ClusterSettings:
-        - Name: containerInsights
-          Value: enabled
 
   # A security group for the containers we will run in Fargate.
   # Rules are added to this security group based on what ingress you

--- a/vpc-ecscluster-lb-fargate-tutorial/vpc-ecscluster-env/v1/infrastructure/cloudformation.yaml
+++ b/vpc-ecscluster-lb-fargate-tutorial/vpc-ecscluster-env/v1/infrastructure/cloudformation.yaml
@@ -72,6 +72,14 @@ Resources:
     Properties:
       SubnetId: !Ref PublicSubnetTwo
       RouteTableId: !Ref PublicRouteTable
+      
+  # ECS Resources
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
 
   # A security group for the containers we will run in Fargate.
   # Rules are added to this security group based on what ingress you


### PR DESCRIPTION
In this PR we are updating the steps around introducing Jinja templating to our service template so it's easier for people less familiar with Cloudformation.

We also rearranged a little of chapter 2 to allow it to flow a little better, tackling only one addition at at time.